### PR TITLE
BGDIINF_SB-1304: Renamed wms:config to wmts_config

### DIFF
--- a/app/helpers/wmts.py
+++ b/app/helpers/wmts.py
@@ -7,7 +7,7 @@ from flask import request
 
 from app import settings
 from app.helpers.s3 import get_s3_img
-from app.helpers.wms_config import get_wms_config_by_layer
+from app.helpers.wmts_config import get_wmts_config_by_layer
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +90,7 @@ def validate_wmts_request(
 
 def validate_restriction(layer_id, time, extension, gagrid, zoom, srid):
     # restriction checks based on bod values / getcap values go here
-    restriction = get_wms_config_by_layer(layer_id)
+    restriction = get_wmts_config_by_layer(layer_id)
     write_s3 = None
     if restriction:
         # timestamp

--- a/app/helpers/wmts_config.py
+++ b/app/helpers/wmts_config.py
@@ -9,17 +9,17 @@ logger = logging.getLogger(__name__)
 restrictions = {}
 
 
-def get_wms_config_by_layer(layer_id):
+def get_wmts_config_by_layer(layer_id):
     try:
         restriction = restrictions[layer_id]
         logger.debug('Restriction for layer %s: %s', layer_id, restriction)
         return restriction
     except KeyError as error:
-        logger.error('No wms configuration found for layer %s', layer_id)
+        logger.error('No wmts configuration found for layer %s', layer_id)
         return None
 
 
-def get_wmsconfig_from_db():
+def get_wmts_config_from_db():
     # Connect to database
     logger.debug(
         'Connecting to %s db on host %s',
@@ -91,4 +91,4 @@ def get_wmsconfig_from_db():
     return _restrictions
 
 
-restrictions = get_wmsconfig_from_db()
+restrictions = get_wmts_config_from_db()


### PR DESCRIPTION
After discussion with @procrastinatio we agreed that this config was more a wmts config as a wms and that the endpoint `/wmsconfig`  from mf-chsdi3 is not needed.