### PR TITLE
BGDIINF_SB-1304: Fixed GetCapabilities 308 Moved Permanently answer

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -174,18 +174,13 @@ app.add_url_rule(
 )
 app.add_url_rule(
     '/EPSG/<int:epsg>/<string:version>/WMTSCapabilities.xml',
-    defaults={'lang': 'de'},
     view_func=view_get_capabilities
 )
 app.add_url_rule(
     '/<string:version>/WMTSCapabilities.EPSG.<int:epsg>.xml',
-    defaults={'lang': 'de'},
     view_func=view_get_capabilities
 )
 app.add_url_rule(
     '/<string:version>/WMTSCapabilities.xml',
-    defaults={
-        'epsg': None, 'lang': None
-    },
-    view_func=view_get_capabilities
+    view_func=view_get_capabilities,
 )

--- a/app/views.py
+++ b/app/views.py
@@ -21,8 +21,9 @@ logger = logging.getLogger(__name__)
 class GetCapabilities(View):
     methods = ['GET']
 
-    def dispatch_request(self, epsg, lang, version):  # pylint: disable=arguments-differ
-        epsg, lang, version = self.get_and_validate_args(epsg, lang, version)
+    # pylint: disable=arguments-differ
+    def dispatch_request(self, version, epsg=None, lang=None):
+        epsg, lang, version = self.get_and_validate_args(version, epsg, lang)
 
         context = self.get_context(self.get_models(lang), epsg, lang)
         return (
@@ -36,7 +37,7 @@ class GetCapabilities(View):
         )
 
     @classmethod
-    def get_and_validate_args(cls, epsg, lang, version):
+    def get_and_validate_args(cls, version, epsg, lang):
         # If no epsg and/or lang argument in path is given, take it
         # from the query arguments.
         if epsg is None:


### PR DESCRIPTION
All the GetCapabilities route with defaults where returning a 308 Moved
Permanently to the simplest form when called with the default values.
This is how flask works with the default see
https://flask.palletsprojects.com/en/2.0.x/api/#url-route-registrations

Therefore remove the defaults in add_url_rule and set the optional epsg
and lang in url as None. Then defaults are handled like for the
/1.0.0/WMTSCapabilities.xml endpoint.