### PR TITLE
BGDIINF_SB-2039: Changed default cache settings and made them all configurable

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -289,6 +289,7 @@ good-names=i,
            Run,
            dictionary,
            id,
+           assertCacheControl,
            _
 
 # Good variable names regexes, separated by a comma. If names match any regex,

--- a/README.md
+++ b/README.md
@@ -180,7 +180,10 @@ All settings can be found in [app/settings.py](app/settings.py) but here below y
 | LOGS_DIR | `./logs` | Logging output directory. Only used by local logging configuration file. |
 | DEFAULT_MODE | `default` | Default operation mode see [Operation Mode](#mode---operation-mode) |
 | UNITTEST_SKIP_XML_VALIDATION | `False` | Validating Get Capabilities XML output in Unittest takes time (~32s), therefore with this variable you can skip this test. |
-| DEFAULT_CACHE | `'public, max-age=1800'` | Default cache settings all requests. Note for GetTile this is overridden by the `cache_ttl` value from BOD. |
+| GET_TILE_DEFAULT_CACHE | `'public, max-age=5184000'` | Default cache settings for GetTile requests (default to 2 months). Note the `max-age` directive is usually overridden by the `cache_ttl` value from BOD. |
+| GET_TILE_ERROR_DEFAULT_CACHE | `'public, max-age=3600'` | Default cache settings for GetTile error responses (default to 1 hour). |
+| GET_TILE_CACHE_TEMPLATE | `'public, max-age={}'` | GetTile `cache-control` header template used with the `cache_ttl` value if present for the layer in the BOD. |
+| GET_CAP_DEFAULT_CACHE | `'public, max-age=5184000'` | GetCapabilities `cache-control` header value (default to 2 months). |
 | FORWARED_ALLOW_IPS | `*` | Sets the gunicorn `forwarded_allow_ips`. See [Gunicorn Doc](https://docs.gunicorn.org/en/stable/settings.html#forwarded-allow-ips). This setting is required in order to `secure_scheme_headers` to work. |
 | FORWARDED_PROTO_HEADER_NAME | `X-Forwarded-Proto` | Sets gunicorn `secure_scheme_headers` parameter to `{${FORWARDED_PROTO_HEADER_NAME}: 'https'}`. This settings is required in order to generate correct URLs in the service responses. See [Gunicorn Doc](https://docs.gunicorn.org/en/stable/settings.html#secure-scheme-headers). |
 | SCRIPT_NAME | `''` | If the service is behind a reverse proxy and not served at the root, the route prefix must be set in `SCRIPT_NAME`. |

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -51,10 +51,13 @@ app.jinja_env.lstrip_blocks = True
 def add_cors_and_cache_header(response):
     # only override cache-control when not present in response
     if 'Cache-Control' not in response.headers:
-        if response.status_code == 200:
-            cache_control = settings.DEFAULT_CACHE
+        if request.endpoint == 'get_tile':
+            if response.status_code == 200:
+                cache_control = settings.GET_TILE_DEFAULT_CACHE
+            else:
+                cache_control = settings.GET_TILE_ERROR_DEFAULT_CACHE
         else:
-            cache_control = settings.NO_CACHE
+            cache_control = settings.GET_CAP_DEFAULT_CACHE
         response.headers.add('Cache-Control', cache_control)
     response.headers.add('Access-Control-Allow-Origin', '*')
     response.headers.add('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS')

--- a/app/helpers/s3.py
+++ b/app/helpers/s3.py
@@ -93,7 +93,9 @@ def put_s3_img_async(wmts_path, content, headers):
             Bucket=settings.AWS_S3_BUCKET_NAME,
             Body=content,
             Key=wmts_path,
-            CacheControl=headers.get('Cache-Control', settings.DEFAULT_CACHE),
+            CacheControl=headers.get(
+                'Cache-Control', settings.GET_TILE_DEFAULT_CACHE
+            ),
             ContentLength=len(content),
             ContentType=headers.get('Content-Type', '')
         )

--- a/app/helpers/utils.py
+++ b/app/helpers/utils.py
@@ -10,6 +10,8 @@ from pyproj import transform
 from flask import jsonify
 from flask import make_response
 
+from app.settings import GET_TILE_CACHE_TEMPLATE
+
 logger = logging.getLogger(__name__)
 
 
@@ -64,7 +66,7 @@ def is_still_valid_tile(exp_header, current_time):
 def set_cache_control(headers, restriction):
     cache_ttl = restriction.get('cache_ttl')
     if cache_ttl:
-        headers['Cache-Control'] = f'public, max-age={cache_ttl}'
+        headers['Cache-Control'] = GET_TILE_CACHE_TEMPLATE.format(cache_ttl)
     return headers
 
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -38,7 +38,18 @@ BOD_DB_PASSWD = os.environ['BOD_DB_PASSWD']
 BOD_DB_CONNECT_TIMEOUT = int(os.getenv('BOD_DB_CONNECT_TIMEOUT', '10'))
 BOD_DB_CONNECT_RETRIES = int(os.getenv('BOD_DB_CONNECT_RETRIES', '3'))
 NO_CACHE = 'public, must-revalidate, proxy-revalidate, max-age=0'
-DEFAULT_CACHE = os.getenv('DEFAULT_CACHE', 'public, max-age=1800')
+GET_TILE_DEFAULT_CACHE = os.getenv(
+    'GET_TILE_DEFAULT_CACHE', 'public, max-age=5184000'
+)
+GET_TILE_ERROR_DEFAULT_CACHE = os.getenv(
+    'GET_TILE_DEFAULT_CACHE', 'public, max-age=3600'
+)
+GET_TILE_CACHE_TEMPLATE = os.getenv(
+    'GET_TILE_CACHE_TEMPLATE', 'public, max-age={}'
+)
+GET_CAP_DEFAULT_CACHE = os.getenv(
+    'GET_CAP_DEFAULT_CACHE', 'public, max-age=5184000'
+)
 DEFAULT_MODE = os.getenv('DEFAULT_MODE', 'default')
 
 # TODO CLEAN_UP: remove S3 second level caching if not needed


### PR DESCRIPTION
Made all cache settings configurable via environment variables and also
made the GetTile and GetCapabilities cache-control independendantly
configurable.

By default GetTile error message were set to no-cache, imho this doesn't
make sense and I changed the default to 1 hour, this can still be by env
variable changed back to no-cache if needed.