### PR TITLE
BGDIINF_SB-2039: HTTP 5xx response cache issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ All settings can be found in [app/settings.py](app/settings.py) but here below y
 | UNITTEST_SKIP_XML_VALIDATION | `False` | Validating Get Capabilities XML output in Unittest takes time (~32s), therefore with this variable you can skip this test. |
 | GET_TILE_DEFAULT_CACHE | `'public, max-age=5184000'` | Default cache settings for GetTile requests (default to 2 months). Note the `max-age` directive is usually overridden by the `cache_ttl` value from BOD. |
 | GET_TILE_ERROR_DEFAULT_CACHE | `'public, max-age=3600'` | Default cache settings for GetTile error responses (default to 1 hour). |
+| ERROR_5XX_DEFAULT_CACHE | `public, max-age=3` | Default cache settings for 5xx HTTP errors |
 | GET_TILE_CACHE_TEMPLATE | `'public, max-age={}'` | GetTile `cache-control` header template used with the `cache_ttl` value if present for the layer in the BOD. |
 | GET_CAP_DEFAULT_CACHE | `'public, max-age=5184000'` | GetCapabilities `cache-control` header value (default to 2 months). |
 | FORWARED_ALLOW_IPS | `*` | Sets the gunicorn `forwarded_allow_ips`. See [Gunicorn Doc](https://docs.gunicorn.org/en/stable/settings.html#forwarded-allow-ips). This setting is required in order to `secure_scheme_headers` to work. |

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -51,7 +51,9 @@ app.jinja_env.lstrip_blocks = True
 def add_cors_and_cache_header(response):
     # only override cache-control when not present in response
     if 'Cache-Control' not in response.headers:
-        if request.endpoint == 'get_tile':
+        if response.status_code >= 500:
+            cache_control = settings.ERROR_5XX_DEFAULT_CACHE
+        elif request.endpoint == 'get_tile':
             if response.status_code == 200:
                 cache_control = settings.GET_TILE_DEFAULT_CACHE
             else:

--- a/app/settings.py
+++ b/app/settings.py
@@ -44,6 +44,9 @@ GET_TILE_DEFAULT_CACHE = os.getenv(
 GET_TILE_ERROR_DEFAULT_CACHE = os.getenv(
     'GET_TILE_DEFAULT_CACHE', 'public, max-age=3600'
 )
+ERROR_5XX_DEFAULT_CACHE = os.getenv(
+    'ERROR_5XX_DEFAULT_CACHE', 'public, max-age=5'
+)
 GET_TILE_CACHE_TEMPLATE = os.getenv(
     'GET_TILE_CACHE_TEMPLATE', 'public, max-age={}'
 )

--- a/tests/unit_tests/test_get_tile.py
+++ b/tests/unit_tests/test_get_tile.py
@@ -358,7 +358,7 @@ class ErrorRequestsTests(unittest.TestCase):
         )
         mock_wms_image.assert_called()
         self.assertEqual(resp.status_code, 502)
-        self.assertEqual(resp.headers['Cache-Control'], 'public, max-age=3600')
+        self.assertEqual(resp.headers['Cache-Control'], 'public, max-age=5')
         self.assertIn('Bad Gateway', resp.get_data(as_text=True))
 
     @patch('app.helpers.wms.get_wms_image')
@@ -370,7 +370,7 @@ class ErrorRequestsTests(unittest.TestCase):
         )
         mock_wms_image.assert_called()
         self.assertEqual(resp.status_code, 502)
-        self.assertEqual(resp.headers['Cache-Control'], 'public, max-age=3600')
+        self.assertEqual(resp.headers['Cache-Control'], 'public, max-age=5')
         self.assertIn('Unable to verify SSL', resp.get_data(as_text=True))
 
     @patch('app.helpers.wms.get_wms_image')
@@ -382,7 +382,7 @@ class ErrorRequestsTests(unittest.TestCase):
         )
         mock_wms_image.assert_called()
         self.assertEqual(resp.status_code, 500)
-        self.assertEqual(resp.headers['Cache-Control'], 'public, max-age=3600')
+        self.assertEqual(resp.headers['Cache-Control'], 'public, max-age=5')
         self.assertIn(
             'Internal server error, please consult logs',
             resp.get_data(as_text=True)
@@ -402,4 +402,4 @@ class ErrorRequestsTests(unittest.TestCase):
             'default/current/21781/20/76/44.png?mode=preview'
         )
         self.assertEqual(resp.status_code, 501)
-        self.assertEqual(resp.headers['Cache-Control'], 'public, max-age=3600')
+        self.assertEqual(resp.headers['Cache-Control'], 'public, max-age=5')


### PR DESCRIPTION
When the service returns an HTTP 5xx answer, the cache-control header
was set to max-age=3600, in this case the answer was cached by
CloudFront and kept for 1 hour. USually 5xx error are temporarly and
should not be cached for too long, therefore cache them by default to
5s.