### PR TITLE
BGDIINF_SB-2294: Fixed timeout issues with S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ NOTE: `max-age` is usually used by the Browser, while `s-maxage` by the server c
 | AWS_S3_BUCKET_NAME | `service-wmts-cache` | S3 bucket name used for 2nd level caching |
 | AWS_S3_REGION_NAME | | AWS Region |
 | AWS_S3_ENDPOINT_URL | | AWS endpoint url if not standard. This allow to use a local S3 instance with minio |
+| HTTP_CLIENT_TIMEOUT | `1` | HTTP client timeout in seconds for AWS S3 GetTile requests |
 
 ### Get Capabilities settings
 

--- a/app/helpers/s3.py
+++ b/app/helpers/s3.py
@@ -2,6 +2,7 @@ import hashlib
 import http.client
 import logging
 from base64 import b64encode
+from socket import timeout as socket_timeout
 from time import perf_counter
 
 import boto3
@@ -58,7 +59,7 @@ def get_s3_file(wmts_path, etag=None):
         path = f"{_get_s3_base_path()}/{wmts_path}"
         logger.debug('Get file from S3: %s%s', settings.AWS_BUCKET_HOST, path)
         http_client = http.client.HTTPConnection(
-            settings.AWS_BUCKET_HOST, timeout=0.5
+            settings.AWS_BUCKET_HOST, timeout=settings.HTTP_CLIENT_TIMEOUT
         )
         http_client.request("GET", path, headers=headers)
         response = http_client.getresponse()
@@ -76,7 +77,7 @@ def get_s3_file(wmts_path, etag=None):
                 response.reason
             )
             return None, None
-    except http.client.HTTPException as error:
+    except (http.client.HTTPException, socket_timeout) as error:
         logger.error(
             'Failed to get S3 file %s: %s', wmts_path, error, exc_info=True
         )

--- a/app/settings.py
+++ b/app/settings.py
@@ -77,6 +77,9 @@ AWS_BUCKET_HOST = f'{AWS_S3_BUCKET_NAME}.s3-{AWS_S3_REGION_NAME}.amazonaws.com'
 if AWS_S3_ENDPOINT_URL is not None:
     AWS_BUCKET_HOST = urlparse(AWS_S3_ENDPOINT_URL).netloc
 
+# HTTP Client Timeout to access S3 bucket [seconds]
+HTTP_CLIENT_TIMEOUT = int(os.getenv('HTTP_CLIENT_TIMEOUT', '1'))
+
 # SQL Alchemy
 # pylint: disable=line-too-long
 SQLALCHEMY_DATABASE_URI = \


### PR DESCRIPTION
During performance testing, we ended up with HTTP GET request timeout on S3 that crashed the services.

To solve this we now cache HTTP timeout exception and in this case would then redirect the request to the wms server.
The timeout has also been increased from 0.5 second to 1 second.