### PR TITLE
Revert "minio volume should be mounted/created  with current user"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,6 @@ services:
     image: minio/minio
     env_file: ./minio.env
     command: server /data
-    user: "${USER_ID:?err}:${GROUP_ID:?err}"
     volumes:
       - type: bind
         source: ${PWD}/.volumes/minio


### PR DESCRIPTION
Reverts geoadmin/service-wmts#45

@ltclm this don't work here is what I have when trying to get minio up

```bash
USER_ID=$(id -u $USER) GROUP_ID=$(id -g $USER) docker-compose up
s3_1         | WARNING: MINIO_ACCESS_KEY and MINIO_SECRET_KEY are deprecated.
s3_1         |          Please use MINIO_ROOT_USER and MINIO_ROOT_PASSWORD
s3_1         | ERROR Unable to initialize backend: mkdir /data/.minio.sys/tmp/0c2fb8d2-29fb-4742-9445-4d9cdd0b5e16: permission denied
```