### PR TITLE
BGDIINF_SB-2583: Made the WMS backend connection settings configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   - [General configuration](#general-configuration)
   - [Cache Configuration](#cache-configuration)
   - [WMS configuration](#wms-configuration)
+    - [WMS Backend Connection settings](#wms-backend-connection-settings)
   - [S3 2nd level caching settings](#s3-2nd-level-caching-settings)
   - [Get Capabilities settings](#get-capabilities-settings)
 - [GetTile](#gettile)
@@ -201,6 +202,18 @@ NOTE: `max-age` is usually used by the Browser, while `s-maxage` by the server c
 | BOD_DB_NAME | | WMS database name |
 | BOD_DB_USER | | WMS database user name |
 | BOD_DB_PASSWD | | WMS database user password |
+
+#### WMS Backend Connection settings
+
+See https://requests.readthedocs.io/en/latest/api/#requests.adapters.HTTPAdapter for description of
+the following variables.
+
+| Variable | Default |
+|---|---|
+| WMS_BACKEND_POOL_CONNECTION | `10` |
+| WMS_BACKEND_POOL_MAXSIZE | `10`|
+| WMS_BACKEND_POOL_BLOCK | `False` |
+| WMS_BACKEND_CONNECTION_MAX_RETRY | `0` |
 
 ### S3 2nd level caching settings
 

--- a/app/helpers/wms.py
+++ b/app/helpers/wms.py
@@ -12,7 +12,15 @@ from app.helpers.utils import get_image_format
 logger = logging.getLogger(__name__)
 
 req_session = requests.Session()
-req_session.mount('http://', requests.adapters.HTTPAdapter(max_retries=0))
+req_session.mount(
+    'http://',
+    requests.adapters.HTTPAdapter(
+        pool_connections=settings.WMS_BACKEND_POOL_CONNECTION,
+        pool_maxsize=settings.WMS_BACKEND_POOL_MAXSIZE,
+        pool_block=settings.WMS_BACKEND_POOL_BLOCK,
+        max_retries=settings.WMS_BACKEND_CONNECTION_MAX_RETRY
+    )
+)
 
 
 def get_backend(url, **kwargs):

--- a/app/settings.py
+++ b/app/settings.py
@@ -100,3 +100,13 @@ LEGENDS_BASE_URL = os.getenv(
 UNITTEST_SKIP_XML_VALIDATION = strtobool(
     os.getenv('UNITTEST_SKIP_XML_VALIDATION', 'False')
 )
+
+# WMS Backend connection settings
+WMS_BACKEND_POOL_CONNECTION = int(
+    os.getenv("WMS_BACKEND_POOL_CONNECTION", "10")
+)
+WMS_BACKEND_POOL_MAXSIZE = int(os.getenv("WMS_BACKEND_POOL_MAXSIZE", "10"))
+WMS_BACKEND_POOL_BLOCK = strtobool(os.getenv("WMS_BACKEND_POOL_BLOCK", "False"))
+WMS_BACKEND_CONNECTION_MAX_RETRY = int(
+    os.getenv("WMS_BACKEND_CONNECTION_MAX_RETRY", "0")
+)


### PR DESCRIPTION
On production we have some pool connection warnings that we would like to get
rid of. The default value here are not changed.

The pool warning are as follow

```
Connection pool is full, discarding connection: wms-bod. Connection pool size: 10
```