### PR TITLE
Fixing the axis order of the WMTS GetCapabilities for EPSG:4326

### DIFF
--- a/app/helpers/utils.py
+++ b/app/helpers/utils.py
@@ -87,7 +87,11 @@ def get_default_tile_matrix_set(epsg):
             gagrid.numberOfYTilesAtZoom(zoom),
             gagrid.getScale(zoom)
         ]
-    # TODO CLEAN_UP check if this legacy mistake is still needed
-    tilematrix_set['MAXY'] = gagrid.MAXY if epsg == '4326' else gagrid.MINX
-    tilematrix_set['MINX'] = gagrid.MINX if epsg == '4326' else gagrid.MAXY
+    # Reversing the axis order for 'EPSG:4326' is needed for now. If we switch
+    # to CRS84, the axis order will be (lng, lat) the other projected CRS
+    # (see commit message for a backround information). Between the two systems,
+    # the tiles are fully compatible.
+    # The variable names (minx, maxy) is very unfortunate though.
+    tilematrix_set['MAXY'] = gagrid.MAXY if int(epsg) == 4326 else gagrid.MINX
+    tilematrix_set['MINX'] = gagrid.MINX if int(epsg) == 4326 else gagrid.MAXY
     return tilematrix_set


### PR DESCRIPTION
TLDR; CRS84 and EPSG:4326 are basically the same, but  EPSG:4326 is using (lat, long) order, while CRS84 is using (long, lat) order. The tiles addresses are the same, but the various WMTS client may or may not consider the axis-order and/or may propose to override it (e.g. QGIS)

Excerpt from  See OGC Two Dimensional Tile Matrix Set and Tile Set Metadata (http://www.opengis.net/doc/IS/tms/2.0)

    WorldCRS84Quad

    Variant 1: World CRS84 Quad (recommended)
    This Tile Matrix Set defines tiles in the Equirectangular Plate Carrée
    projection in the CRS84 CRS for the whole world.
    PointOfOrigin: -180, 90

    Variant 2: World EPSG:4326 Quad

    Despite what is stated in Clause 6.2.1.1, some implementers prefer to
    define the previous TileMatrixSet using the CRS http://www.opengis.net/def/crs/EPSG/0/4326.
    The definition is the same as the variant defined using http://www.opengis.net/def/crs/OGC/1.3/CRS84
    except that CRS coordinates are expressed in latitude, longitude order,
    affecting the PointOfOrigin and the BoundingBox encoding only. For most
    practical purposes, both variations are equivalent because a TileMatrixSet
    primarily defines the tiling structure as well as the scale/resolution at
    each tile matrix, rather than how the data within each tile is stored. For
    many raster and vector tiles formats, CRS84 and EPSG:4326 are equivalent
    as a particular axis order is enforced. Additional parameters to an API
    for example could also override the default axis order by specifying the
    CRS as either CRS84 or EPSG:4326.

    If possible, defining it in terms of http://www.opengis.net/def/crs/OGC/1.3/CRS84
    is recommended instead of this variation, because it uses the CRS
    consistent with the TileMatrixSet URI. However, we introduce it here to
    clarify how an implementation based on EPSG:4326 should look like and
    avoid confusion.

    This Tile Matrix Set defines tiles in the Equirectangular Plate Carrée
    projection in the EPSG:4326 CRS for the whole world.

    PointOfOrigin: 90, -180