### PR TITLE
BGDIINF_SB-2844: max zoom level for swissimage

### DIFF
--- a/app/helpers/utils.py
+++ b/app/helpers/utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import math
 import re
 from datetime import datetime
 
@@ -70,7 +71,15 @@ def set_cache_control(headers, restriction):
     return headers
 
 
-def get_closest_zoom(resolution, epsg):
+def resolution_factor_at_latitude(latitude):
+    return math.cos(latitude * (math.pi / 180.0))
+
+
+# Zoom is defined at the Equator for WebMercator, layer defined at the
+# latitude of Switzerland have to be corrected.
+def get_closest_zoom(resolution, epsg, latitude=0.0):
+    if int(epsg) == 3857:
+        resolution /= resolution_factor_at_latitude(latitude)
     tilegrid = getTileGrid(int(epsg))()
     return tilegrid.getClosestZoom(float(resolution))
 

--- a/app/templates/Layers.xml.jinja
+++ b/app/templates/Layers.xml.jinja
@@ -37,7 +37,7 @@
                 {% endfor %}
             </Dimension>
             <TileMatrixSetLink>
-                <TileMatrixSet>{{ epsg }}_{{ layer.resolution_max|get_closest_zoom(epsg) }}</TileMatrixSet>
+                <TileMatrixSet>{{ epsg }}_{{ layer.resolution_max|get_closest_zoom(epsg, latitude=standard_latitude) }}</TileMatrixSet>
             </TileMatrixSetLink>
             {# ## ATTENTION: s3 tiles have a row/col order, mapproxy ones the standard col/row #}
             {% for format in layer.formats %}

--- a/app/views.py
+++ b/app/views.py
@@ -18,6 +18,8 @@ from app.models import localized_models
 
 logger = logging.getLogger(__name__)
 
+STANDARD_LATITUDE_FOR_SWITZERLAND = 47.0
+
 
 class GetCapabilities(View):
     methods = ['GET']
@@ -107,7 +109,8 @@ class GetCapabilities(View):
             'epsg': epsg,
             'default_tile_matrix_set': get_default_tile_matrix_set(epsg),
             'legend_base_url': app.config["LEGENDS_BASE_URL"],
-            'language': lang
+            'language': lang,
+            'standard_latitude': STANDARD_LATITUDE_FOR_SWITZERLAND
         }
         logger.debug('Data context created in %fs', time.time() - start)
         return context


### PR DESCRIPTION
correcting the max zoom in the tilegridset webmercator for respect of the latitude of Swwitzerland.

Most layer in the BGDI/NGDI are only available in the tiny area of Switzerland and defined in this area (resolution, zoom). When using global TileMatrix set like the Spherical WebMercator one, where these paramters are defined at the Equator, we have to correct them to match those of the area of interest.