### PR TITLE
BGDIINF_SB-2985: - #minor

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -70,8 +70,9 @@ class GetCapabilities(View):
     @classmethod
     def get_layers_zoom_level_set(cls, epsg, layers_capabilities):
         zoom_levels = set()
+        latitude = STANDARD_LATITUDE_FOR_SWITZERLAND if epsg == 3857 else 0.0
         for layer in layers_capabilities:
-            zoom = get_closest_zoom(layer.resolution_max, epsg)
+            zoom = get_closest_zoom(layer.resolution_max, epsg, latitude)
             zoom_levels.add(zoom)
         return zoom_levels
 


### PR DESCRIPTION
this fix will create the list of tilematrixset at he bottom of the getcap using the swiss latitude parameter.

without this adjustment the list of tilematrixset is not matching the referenced tilmatrixsets from the layer list. some layers can reference a tilematrixset which does not exist. Some esri clients cannot handle this and therefore not parse the webmercator getcap anymore.

the fixed version:
```
❯ grep 3857_ 3857.xml | sort | uniq -c
      1             <ows:Identifier>3857_11</ows:Identifier>
      1             <ows:Identifier>3857_12</ows:Identifier>
      1             <ows:Identifier>3857_13</ows:Identifier>
      1             <ows:Identifier>3857_14</ows:Identifier>
      1             <ows:Identifier>3857_16</ows:Identifier>
      1             <ows:Identifier>3857_17</ows:Identifier>
      1             <ows:Identifier>3857_18</ows:Identifier>
      1             <ows:Identifier>3857_19</ows:Identifier>
      1             <ows:Identifier>3857_20</ows:Identifier>
      3                 <TileMatrixSet>3857_11</TileMatrixSet>
     23                 <TileMatrixSet>3857_12</TileMatrixSet>
     20                 <TileMatrixSet>3857_13</TileMatrixSet>
      2                 <TileMatrixSet>3857_14</TileMatrixSet>
     71                 <TileMatrixSet>3857_16</TileMatrixSet>
     52                 <TileMatrixSet>3857_17</TileMatrixSet>
    366                 <TileMatrixSet>3857_18</TileMatrixSet>
     62                 <TileMatrixSet>3857_19</TileMatrixSet>
      3                 <TileMatrixSet>3857_20</TileMatrixSet>

```

the old version
``` 
❯ grep 3857_ SwisstopoWMTS_GetCapabilities-borked.xml | sort | uniq -c
      1             <ows:Identifier>3857_12</ows:Identifier>
      1             <ows:Identifier>3857_13</ows:Identifier>
      1             <ows:Identifier>3857_14</ows:Identifier>
      1             <ows:Identifier>3857_15</ows:Identifier>
      1             <ows:Identifier>3857_16</ows:Identifier>
      1             <ows:Identifier>3857_17</ows:Identifier>
      1             <ows:Identifier>3857_18</ows:Identifier>
      1             <ows:Identifier>3857_19</ows:Identifier>
      1             <ows:Identifier>3857_20</ows:Identifier>
      1             <ows:Identifier>3857_21</ows:Identifier>
      3                 <TileMatrixSet>3857_11</TileMatrixSet>
     23                 <TileMatrixSet>3857_12</TileMatrixSet>
     20                 <TileMatrixSet>3857_13</TileMatrixSet>
      2                 <TileMatrixSet>3857_14</TileMatrixSet>
     71                 <TileMatrixSet>3857_16</TileMatrixSet>
     52                 <TileMatrixSet>3857_17</TileMatrixSet>
    366                 <TileMatrixSet>3857_18</TileMatrixSet>
     62                 <TileMatrixSet>3857_19</TileMatrixSet>
      3                 <TileMatrixSet>3857_20</TileMatrixSet>

```