### PR TITLE
PB-569 Use docker compose plugin instead of docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The **Make** targets assume you have
 - **libpq-dev**
 - **curl**
 - **docker**
-- **docker-compose**
+- **docker-compose-plugin**
 
 installed.
 
@@ -81,7 +81,7 @@ make setup
 Then you need to run some local containers (DB, WMS-BOD)
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 That's it, you're ready to work.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   wms-bod:
     image: camptocamp/mapserver:7.6


### PR DESCRIPTION
The README needed updating as well as the version line in `docker-compose.yml`. But this PR tests if the buildspec update of https://github.com/geoadmin/infra-terraform-bgdi-builder/pull/273 works