### PR TITLE
PB-1668: Use a different logger for access logs

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -20,6 +20,7 @@ from app.version import APP_VERSION
 from app.views import GetCapabilities
 
 logger = logging.getLogger(__name__)
+access_logger = logging.getLogger('app.access_logs')
 
 
 # Log each requests
@@ -31,7 +32,7 @@ def log_request():
 
 @app.after_request
 def log_response(response):
-    logger.info(
+    access_logger.info(
         "%s %s - %s",
         request.method,
         request.path,


### PR DESCRIPTION
This will ease the logs filtering on Kibana so we can filter the logs to obtain
some requests metrics.