### PR TITLE
PB-2315: fix readiness check - #patch

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -71,17 +71,19 @@ def liveness():
 
 @app.route('/checker/ready', methods=['GET'])
 def readiness():
-    wms_ok_string = 'No query information to decode. ' + \
-                    'QUERY_STRING is set, but empty.\n'
+    wms_ok_marker = (
+        'No query information to decode. QUERY_STRING is set, but empty.'
+    )
 
     content = get_wms_backend_readiness()
 
-    if content.decode('ascii') != wms_ok_string:
+    content_str = content.decode('ascii', errors='replace')
+    if wms_ok_marker not in content_str:
         logger.error(
             'Incomprehensible WMS backend %s answer: %s. '
             'WMS is probably not ready yet.',
             settings.WMS_BACKEND_READY,
-            content.decode('ascii')
+            content_str
         )
         abort(503, 'Incomprehensible answer. WMS is probably not ready yet.')
     return make_response(jsonify({'success': True, 'message': 'OK'}))

--- a/tests/unit_tests/test_checker.py
+++ b/tests/unit_tests/test_checker.py
@@ -39,3 +39,20 @@ class CheckerTests(unittest.TestCase):
         resp = self.app.get('/checker/ready')
         mock_get_backend.assert_called_once()
         self.assertEqual(resp.status_code, 502)
+
+    @patch('app.routes.get_wms_backend_readiness')
+    def test_backend_checker_ready(self, mock_readiness):
+        mock_readiness.return_value = (
+            b'No query information to decode. QUERY_STRING is set, but empty.'
+        )
+        resp = self.app.get('/checker/ready')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json, {'success': True, 'message': 'OK'})
+
+    @patch('app.routes.get_wms_backend_readiness')
+    def test_backend_checker_missing_marker(self, mock_readiness):
+        mock_readiness.return_value = (
+            b'<HTML><BODY>Apache is up but MapServer is not.</BODY></HTML>'
+        )
+        resp = self.app.get('/checker/ready')
+        self.assertEqual(resp.status_code, 503)


### PR DESCRIPTION
The WMS backend now returns the MapServer message wrapped in HTML, causing the exact-string equality check to fail and WMTS pods to remain unready.

Replace the equality check against `wms_ok_string` with a substring search for the marker without trailing newline, and decode with `errors='replace'` to avoid failures on unexpected bytes.

Add unit tests for the ready (mocked happy path) and missing-marker (503) cases.